### PR TITLE
[IMPL] Broker Sink

### DIFF
--- a/events/drain/sink_broker.go
+++ b/events/drain/sink_broker.go
@@ -1,0 +1,76 @@
+package drain
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/botchris/go-pubsub"
+)
+
+// BrokerSinkOpts is a type for broker sink options.
+type BrokerSinkOpts func(config *brokerSinkConfig)
+
+type brokerSink[M any] struct {
+	*baseSink
+	broker pubsub.Broker
+	topic  pubsub.Topic
+	conf   brokerSinkConfig
+}
+
+type brokerSinkConfig struct {
+	timeout time.Duration
+}
+
+// NewBrokerSink creates a new broker sink.
+func NewBrokerSink[M any](broker pubsub.Broker, topic pubsub.Topic, opts ...BrokerSinkOpts) (Sink[M], error) {
+	// defaults.
+	conf := &brokerSinkConfig{
+		timeout: 5 * time.Second,
+	}
+
+	for _, opt := range opts {
+		opt(conf)
+	}
+
+	if broker == nil {
+		return nil, fmt.Errorf("a valid broker must be provided")
+	}
+
+	if topic == "" {
+		return nil, fmt.Errorf("a valid topic must be provided")
+	}
+
+	if conf.timeout <= 0 {
+		return nil, fmt.Errorf("a timeout greater than 0 must be provided")
+	}
+
+	return &brokerSink[M]{
+		baseSink: newCloseTrait(),
+		broker:   broker,
+		topic:    topic,
+		conf:     *conf,
+	}, nil
+}
+
+func (s *brokerSink[M]) Write(message M) error {
+	if s.baseSink.IsClosed() {
+		return fmt.Errorf("%w: broker writer sink could not publish message %T", ErrSinkClosed, message)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), s.conf.timeout)
+	defer cancel()
+
+	if err := s.broker.Publish(ctx, s.topic, message); err != nil {
+		return fmt.Errorf("%w: broker writer sink could not publish message %T", err, message)
+	}
+
+	return nil
+}
+
+// BrokerSinkWithTimeout sets the timeout for the broker sink.
+func BrokerSinkWithTimeout(timeout time.Duration) BrokerSinkOpts {
+	return func(config *brokerSinkConfig) {
+		config.timeout = timeout
+	}
+}

--- a/events/drain/sink_broker_test.go
+++ b/events/drain/sink_broker_test.go
@@ -1,0 +1,84 @@
+package drain_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/botchris/go-pubsub"
+	"github.com/botchris/go-pubsub/provider/memory"
+	"github.com/stretchr/testify/require"
+	"github.com/tangelo-labs/go-domain/events/drain"
+)
+
+func Test_BrokerSink(t *testing.T) {
+	t.Run("GIVEN a broker sink constructor WHEN we input invalid broker", func(t *testing.T) {
+		_, err := drain.NewBrokerSink[struct{}](nil, "topic")
+
+		t.Run("THEN returns error", func(t *testing.T) {
+			require.Error(t, err)
+		})
+	})
+
+	t.Run("GIVEN a broker sink constructor WHEN we input invalid topic", func(t *testing.T) {
+		_, err := drain.NewBrokerSink[struct{}](nil, "topic")
+
+		t.Run("THEN returns error", func(t *testing.T) {
+			require.Error(t, err)
+		})
+	})
+
+	t.Run("GIVEN a broker sink constructor WHEN we input invalid timeout", func(t *testing.T) {
+		_, err := drain.NewBrokerSink[struct{}](nil, "topic", drain.BrokerSinkWithTimeout(0))
+
+		t.Run("THEN returns error", func(t *testing.T) {
+			require.Error(t, err)
+		})
+	})
+
+	t.Run("GIVEN a closed broker sink", func(t *testing.T) {
+		brk := memory.NewBroker()
+
+		sink, err := drain.NewBrokerSink[struct{}](brk, "topic")
+		require.NoError(t, err)
+
+		err = sink.Close()
+		require.NoError(t, err)
+
+		t.Run("WHEN we write a message", func(t *testing.T) {
+			err := sink.Write(struct{}{})
+
+			t.Run("THEN the sink should not accept messages", func(t *testing.T) {
+				require.ErrorIs(t, err, drain.ErrSinkClosed)
+			})
+		})
+	})
+
+	t.Run("GIVEN a broker sink", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+
+		brk := memory.NewBroker()
+
+		sink, err := drain.NewBrokerSink[struct{}](brk, "topic")
+		require.NoError(t, err)
+
+		published := false
+
+		_, err = brk.Subscribe(ctx, "topic", pubsub.NewHandler(func(ctx context.Context, topic pubsub.Topic, msg struct{}) error {
+			published = true
+
+			return nil
+		}))
+		require.NoError(t, err)
+
+		t.Run("WHEN we write a message", func(t *testing.T) {
+			err := sink.Write(struct{}{})
+
+			t.Run("THEN the message is published to the topic", func(t *testing.T) {
+				require.NoError(t, err)
+				require.True(t, published)
+			})
+		})
+	})
+}

--- a/events/drain/sink_broker_test.go
+++ b/events/drain/sink_broker_test.go
@@ -8,12 +8,13 @@ import (
 	"github.com/botchris/go-pubsub"
 	"github.com/botchris/go-pubsub/provider/memory"
 	"github.com/stretchr/testify/require"
+	"github.com/tangelo-labs/go-domain/events"
 	"github.com/tangelo-labs/go-domain/events/drain"
 )
 
 func Test_BrokerSink(t *testing.T) {
 	t.Run("GIVEN a broker sink constructor WHEN we input invalid broker", func(t *testing.T) {
-		_, err := drain.NewBrokerSink[struct{}](nil, "topic")
+		_, err := drain.NewBrokerSink[events.Event](nil, "topic")
 
 		t.Run("THEN returns error", func(t *testing.T) {
 			require.Error(t, err)
@@ -21,7 +22,7 @@ func Test_BrokerSink(t *testing.T) {
 	})
 
 	t.Run("GIVEN a broker sink constructor WHEN we input invalid topic", func(t *testing.T) {
-		_, err := drain.NewBrokerSink[struct{}](nil, "topic")
+		_, err := drain.NewBrokerSink[events.Event](nil, "topic")
 
 		t.Run("THEN returns error", func(t *testing.T) {
 			require.Error(t, err)
@@ -29,7 +30,7 @@ func Test_BrokerSink(t *testing.T) {
 	})
 
 	t.Run("GIVEN a broker sink constructor WHEN we input invalid timeout", func(t *testing.T) {
-		_, err := drain.NewBrokerSink[struct{}](nil, "topic", drain.BrokerSinkWithTimeout(0))
+		_, err := drain.NewBrokerSink[events.Event](nil, "topic", drain.BrokerSinkWithTimeout(0))
 
 		t.Run("THEN returns error", func(t *testing.T) {
 			require.Error(t, err)
@@ -39,7 +40,7 @@ func Test_BrokerSink(t *testing.T) {
 	t.Run("GIVEN a closed broker sink", func(t *testing.T) {
 		brk := memory.NewBroker()
 
-		sink, err := drain.NewBrokerSink[struct{}](brk, "topic")
+		sink, err := drain.NewBrokerSink[events.Event](brk, "topic")
 		require.NoError(t, err)
 
 		err = sink.Close()
@@ -60,7 +61,7 @@ func Test_BrokerSink(t *testing.T) {
 
 		brk := memory.NewBroker()
 
-		sink, err := drain.NewBrokerSink[struct{}](brk, "topic")
+		sink, err := drain.NewBrokerSink[events.Event](brk, "topic")
 		require.NoError(t, err)
 
 		published := false


### PR DESCRIPTION
Implementing a Broker Sink that uses `github.com/botchris/go-pubsub` `pubsub.Broker` and publishes sunken events to the configured `pubsub.Topic`